### PR TITLE
Fix: Correct favicon and manifest links in post.html

### DIFF
--- a/post.html
+++ b/post.html
@@ -20,10 +20,9 @@
      crossorigin="anonymous"></script>
     
     <!-- Favicon -->
-    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
+    <link rel="icon" href="images/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
-    <link rel="manifest" href="site.webmanifest">
+    <link rel="manifest" href="images/site.webmanifest">
     
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">


### PR DESCRIPTION
Updated favicon and manifest links in post.html to match index.html, resolving potential 404 errors. This change was made during the AdSense investigation phase.