### PR TITLE
Fix auth middleware export

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -3,7 +3,7 @@ const User = require('../models/User');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'sua-chave-secreta-aqui';
 
-module.exports = async (req, res, next) => {
+const auth = async (req, res, next) => {
     try {
         // Pegar token do header
         const token = req.header('Authorization')?.replace('Bearer ', '');


### PR DESCRIPTION
## Summary
- define `auth` middleware function in `middleware/auth.js` instead of exporting an anonymous function

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad1b723483339d07610a3470799d