### PR TITLE
Limit AdSense ads to footer and anchor

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="google-adsense-account" content="ca-pub-7782077901383981">
     <title>EduPrado.me | Tecnologia e Inteligência Artificial</title>
     
     <!-- Favicon -->
@@ -23,6 +22,12 @@
     <!-- Google AdSense -->
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7782077901383981"
      crossorigin="anonymous"></script>
+    <script>
+        (adsbygoogle = window.adsbygoogle || []).push({
+            google_ad_client: "ca-pub-7782077901383981",
+            overlays: { bottom: true }
+        });
+    </script>
     
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

--- a/post.html
+++ b/post.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="google-adsense-account" content="ca-pub-7782077901383981">
     <title>Blog Post - Edu Prado</title>
     
     <!-- Google Analytics -->
@@ -18,6 +17,12 @@
     <!-- Google AdSense -->
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7782077901383981"
      crossorigin="anonymous"></script>
+    <script>
+        (adsbygoogle = window.adsbygoogle || []).push({
+            google_ad_client: "ca-pub-7782077901383981",
+            overlays: { bottom: true }
+        });
+    </script>
     
     <!-- Favicon -->
     <link rel="icon" href="images/favicon.ico">
@@ -59,19 +64,6 @@
             
             <div class="post-image">
                 <img id="post-image" src="" alt="Post Image">
-            </div>
-            
-            <!-- Anúncio do Google AdSense - Meio -->
-            <div class="ad-container">
-                <ins class="adsbygoogle"
-                     style="display:block"
-                     data-ad-client="ca-pub-7782077901383981"
-                     data-ad-slot="8139493248"
-                     data-ad-format="auto"
-                     data-full-width-responsive="true"></ins>
-                <script>
-                     (adsbygoogle = window.adsbygoogle || []).push({});
-                </script>
             </div>
             
             <div class="post-content" id="post-content">


### PR DESCRIPTION
## Summary
- remove auto AdSense meta tag and disable mid-page auto ads
- add explicit anchor script so only footer ad and bottom sticky ad remain
- drop mid-article ad block from post template

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689651168cb483339e63b2ae27e5b3a0