### PR TITLE
feat: add Next.js site scaffold

### DIFF
--- a/next-site/.gitignore
+++ b/next-site/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/next-site/QA_CHECKLIST.md
+++ b/next-site/QA_CHECKLIST.md
@@ -1,0 +1,19 @@
+# Checklist de QA
+
+## Acessibilidade
+- [ ] Textos com contraste adequado
+- [ ] Navegação por teclado
+- [ ] Headings em ordem lógica
+
+## SEO
+- [ ] Títulos H1 únicos por página
+- [ ] Metatags e Open Graph preenchidos
+- [ ] Sitemap e robots atualizados
+
+## Performance
+- [ ] Build sem erros
+- [ ] Imagens otimizadas
+
+## Links
+- [ ] Links internos funcionando
+- [ ] Links externos com `rel="noopener"`

--- a/next-site/README.md
+++ b/next-site/README.md
@@ -1,0 +1,30 @@
+# EduPrado.me (Next.js)
+
+Site pessoal de Eduardo Prado construido com Next.js e Tailwind CSS.
+
+## Desenvolvimento
+
+```bash
+npm install
+npm run dev
+```
+
+## Build e Deploy
+
+```bash
+npm run build
+npm start
+```
+
+Para publicar na Vercel:
+1. Faça fork do repositório e importe em [Vercel](https://vercel.com).
+2. Defina a pasta `next-site` como raiz do projeto.
+3. Configure o build command `npm run build` e output `.next`.
+
+## Estrutura
+- `pages/` páginas estáticas e dinâmicas
+- `components/` componentes reutilizáveis
+- `data/` conteúdo inicial de posts e projetos
+
+## Licença
+Livre para uso educacional.

--- a/next-site/components/Post.js
+++ b/next-site/components/Post.js
@@ -1,0 +1,29 @@
+import Head from 'next/head'
+
+function readingTime(text) {
+  const words = text.split(/\s+/).length
+  return Math.ceil(words / 200)
+}
+
+export default function Post({ post }) {
+  const minutes = readingTime(post.content)
+  return (
+    <>
+      <Head>
+        <title>{post.title} | Edu Prado</title>
+        <meta name="description" content={post.excerpt} />
+        <meta property="og:title" content={post.title} />
+        <meta property="og:description" content={post.excerpt} />
+      </Head>
+      <article className="prose lg:prose-xl mx-auto py-8">
+        <h1>{post.title}</h1>
+        <p className="text-sm text-gray-500">{post.date} • {minutes} min de leitura</p>
+        <div dangerouslySetInnerHTML={{ __html: post.content }} />
+        <div className="p-4 border rounded mt-8 bg-gray-50">
+          <h2 className="font-semibold mb-2">Aplicar na prática</h2>
+          <p>{post.apply}</p>
+        </div>
+      </article>
+    </>
+  )
+}

--- a/next-site/components/ProjectCard.js
+++ b/next-site/components/ProjectCard.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function ProjectCard({ slug, title, excerpt, image }) {
+  return (
+    <div className="border rounded overflow-hidden flex flex-col">
+      {image && <img src={image} alt={title} className="w-full h-48 object-cover" />}
+      <div className="p-4 flex-1 flex flex-col">
+        <h3 className="text-xl font-semibold mb-2">{title}</h3>
+        <p className="mb-4 flex-1">{excerpt}</p>
+        <Link href={`/projetos/${slug}`} className="text-blue-600 font-medium mt-auto">Ver detalhes</Link>
+      </div>
+    </div>
+  )
+}

--- a/next-site/data/posts.js
+++ b/next-site/data/posts.js
@@ -1,0 +1,29 @@
+export const posts = [
+  {
+    slug: 'ia-sem-hype-por-onde-comecar',
+    title: 'IA sem hype: por onde começar',
+    date: '2024-06-01',
+    tag: 'IA',
+    excerpt: 'Um guia direto para iniciar iniciativas de IA que geram valor em até 14 dias.',
+    content: `<p>Comece escolhendo um processo com dor clara e dados acessíveis. Foque em medir impacto desde o dia zero e evite promessas vagas.</p><h2>Mapeie uma dor real</h2><p>Identifique onde tempo ou dinheiro estão sendo desperdiçados. Sem dor, não há urgência.</p><h2>Defina métrica e experimento</h2><p>Uma métrica simples guia decisões e permite avaliar o piloto em semanas.</p>`,
+    apply: 'Escolha um processo, defina uma métrica objetiva e rode um piloto em 14 dias.'
+  },
+  {
+    slug: 'framework-decisao-pilotos-ia',
+    title: 'Framework de decisão para pilotos de IA',
+    date: '2024-06-08',
+    tag: 'Estratégia',
+    excerpt: 'Critérios simples para decidir se um piloto de IA vale o investimento.',
+    content: `<p>Nem todo problema precisa de IA. Use um filtro rápido para evitar desperdício.</p><h2>Critérios</h2><ul><li>Dado disponível e de qualidade</li><li>Métrica clara de sucesso</li><li>Time comprometido</li></ul>`,
+    apply: 'Use os critérios para priorizar pilotos no seu roadmap e diga não ao resto.'
+  },
+  {
+    slug: 'licoes-open-finance-produtos-dados',
+    title: 'Lições práticas de Open Finance para produtos de dados',
+    date: '2024-06-15',
+    tag: 'Dados',
+    excerpt: 'Aprendizados ao construir produtos de dados em ambiente regulado.',
+    content: `<p>Open Finance mostrou que abrir dados não basta; é preciso conectá-los a problemas reais.</p><h2>Governança que habilita</h2><p>Regras simples e foco em valor aceleram a adoção.</p>`,
+    apply: 'Simplifique a governança e foque em casos de uso com ROI claro.'
+  }
+]

--- a/next-site/data/projects.js
+++ b/next-site/data/projects.js
@@ -1,0 +1,32 @@
+export const projects = [
+  {
+    slug: 'baixaia',
+    title: 'BaixaIA',
+    image: '/images/baixaia.jpg',
+    excerpt: 'Conteúdo visual e experimental de IA para engajar e educar.',
+    challenge: 'Engajar profissionais de negócios com o potencial da IA de forma acessível.',
+    approach: 'Produção de vídeos curtos e peças visuais que mostram usos reais de IA com humor.',
+    result: 'Crescimento orgânico de 5k+ seguidores e 50k visualizações em 3 meses.',
+    learnings: 'Narrativas leves aceleram a adoção e reduzem resistência.'
+  },
+  {
+    slug: 'open-finance-dados',
+    title: 'Open Finance & Dados',
+    image: '/images/openfinance.jpg',
+    excerpt: 'Governança e produtos de dados com foco em valor.',
+    challenge: 'Estruturar governança e uso de dados abertos para gerar novos produtos.',
+    approach: 'Framework de governança e sprints de co-criação com equipes de produto.',
+    result: 'Lançamento de 2 APIs e aumento de 15% no NPS em 6 meses.',
+    learnings: 'Governança simples evita burocracia e mantém foco em valor.'
+  },
+  {
+    slug: 'palestras-workshops',
+    title: 'Palestras & Workshops',
+    image: '/images/palestras.jpg',
+    excerpt: 'Trilhas por maturidade para iniciar discussões de IA sem hype.',
+    challenge: 'Ajudar lideranças a tomar decisões informadas sobre IA.',
+    approach: 'Conteúdo modular dividido por níveis de maturidade e setor.',
+    result: 'Mais de 30 sessões com executivos e avaliação média 4.9/5.',
+    learnings: 'Discussão franca sobre limitações aumenta confiança na execução.'
+  }
+]

--- a/next-site/next.config.js
+++ b/next-site/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  reactStrictMode: true,
+  i18n: {
+    locales: ['pt-BR'],
+    defaultLocale: 'pt-BR'
+  }
+}

--- a/next-site/package.json
+++ b/next-site/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "eduprado-site",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "npm run build"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.4.1"
+  }
+}

--- a/next-site/pages/_app.js
+++ b/next-site/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css'
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/next-site/pages/_document.js
+++ b/next-site/pages/_document.js
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="pt-BR">
+      <Head />
+      <body className="bg-gray-50 text-gray-900">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/next-site/pages/blog/[slug].js
+++ b/next-site/pages/blog/[slug].js
@@ -1,0 +1,11 @@
+import { useRouter } from 'next/router'
+import Post from '../../components/Post'
+import { posts } from '../../data/posts'
+
+export default function BlogPost() {
+  const router = useRouter()
+  const { slug } = router.query
+  const post = posts.find(p => p.slug === slug)
+  if (!post) return null
+  return <Post post={post} />
+}

--- a/next-site/pages/blog/index.js
+++ b/next-site/pages/blog/index.js
@@ -1,0 +1,31 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import { posts } from '../../data/posts'
+
+export default function Blog() {
+  return (
+    <>
+      <Head>
+        <title>Blog | Edu Prado</title>
+        <meta name="description" content="Artigos práticos sobre IA, dados e transformação digital." />
+        <meta property="og:title" content="Blog | Edu Prado" />
+        <meta property="og:description" content="Artigos práticos sobre IA, dados e transformação digital." />
+      </Head>
+      <main className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-6">Blog</h1>
+        <div className="space-y-8">
+          {posts.map(post => (
+            <article key={post.slug} className="border-b pb-6">
+              <h2 className="text-2xl font-semibold mb-2">
+                <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+              </h2>
+              <p className="text-sm text-gray-500 mb-2">{post.date} • {post.tag}</p>
+              <p className="mb-2">{post.excerpt}</p>
+              <Link href={`/blog/${post.slug}`} className="text-blue-600 font-medium">Ler mais</Link>
+            </article>
+          ))}
+        </div>
+      </main>
+    </>
+  )
+}

--- a/next-site/pages/contato.js
+++ b/next-site/pages/contato.js
@@ -1,0 +1,37 @@
+import Head from 'next/head'
+
+export default function Contato() {
+  return (
+    <>
+      <Head>
+        <title>Contato | Edu Prado</title>
+        <meta name="description" content="Agende 30 minutos para mapear oportunidades reais." />
+        <meta property="og:title" content="Contato | Edu Prado" />
+        <meta property="og:description" content="Agende 30 minutos para mapear oportunidades reais." />
+      </Head>
+      <main className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-6">Contato</h1>
+        <form className="max-w-xl space-y-4">
+          <div>
+            <label className="block mb-1" htmlFor="nome">Nome</label>
+            <input id="nome" name="nome" type="text" className="w-full border p-2 rounded" />
+          </div>
+          <div>
+            <label className="block mb-1" htmlFor="email">E-mail</label>
+            <input id="email" name="email" type="email" className="w-full border p-2 rounded" />
+          </div>
+          <div>
+            <label className="block mb-1" htmlFor="org">Organização</label>
+            <input id="org" name="org" type="text" className="w-full border p-2 rounded" />
+          </div>
+          <div>
+            <label className="block mb-1" htmlFor="mensagem">Mensagem</label>
+            <textarea id="mensagem" name="mensagem" rows="4" className="w-full border p-2 rounded" />
+          </div>
+          <button type="submit" className="px-6 py-3 bg-blue-600 text-white rounded">Enviar</button>
+        </form>
+        <p className="mt-6">Ou <a href="https://calendly.com" className="text-blue-600">agende 30 min</a>.</p>
+      </main>
+    </>
+  )
+}

--- a/next-site/pages/index.js
+++ b/next-site/pages/index.js
@@ -1,0 +1,77 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import ProjectCard from '../components/ProjectCard'
+import { projects } from '../data/projects'
+import { posts } from '../data/posts'
+
+export default function Home() {
+  const featuredPosts = posts.slice(0, 3)
+  return (
+    <>
+      <Head>
+        <title>Edu Prado | IA e Transformação Digital</title>
+        <meta name="description" content="IA e Transformação Digital sem fumaça. Resultados reais." />
+        <meta property="og:title" content="Edu Prado | IA e Transformação Digital" />
+        <meta property="og:description" content="IA e Transformação Digital sem fumaça. Resultados reais." />
+      </Head>
+      <main className="container mx-auto px-4">
+        <section className="py-20 text-center">
+          <h1 className="text-4xl font-bold mb-4">IA e Transformação Digital, sem fumaça. Resultados reais.</h1>
+          <p className="text-lg mb-6">Sou Eduardo Prado. Traduzo dados e IA em impacto mensurável para negócios e setor público.</p>
+          <div className="flex flex-col sm:flex-row justify-center gap-4">
+            <Link href="/contato" className="px-6 py-3 bg-blue-600 text-white rounded">Agendar conversa</Link>
+            <Link href="#newsletter" className="px-6 py-3 border border-blue-600 text-blue-600 rounded">Assinar newsletter</Link>
+          </div>
+        </section>
+
+        <section className="py-12">
+          <h2 className="text-2xl font-semibold mb-6">O que eu faço</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            <div className="p-4 border rounded">
+              <h3 className="font-semibold mb-2">Consultoria &amp; projetos-piloto de IA</h3>
+              <p>Mapeamos oportunidades e executamos pilotos para gerar valor em semanas.</p>
+            </div>
+            <div className="p-4 border rounded">
+              <h3 className="font-semibold mb-2">Palestras &amp; workshops executivos</h3>
+              <p>Conteúdo sob medida para líderes que precisam decidir sem hype.</p>
+            </div>
+            <div className="p-4 border rounded">
+              <h3 className="font-semibold mb-2">Mentorias 1:1 e advisory</h3>
+              <p>Acompanhamento direto para acelerar aprendizado e execução.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12" id="projetos">
+          <h2 className="text-2xl font-semibold mb-6">Projetos em destaque</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {projects.map(p => (
+              <ProjectCard key={p.slug} {...p} />
+            ))}
+          </div>
+        </section>
+
+        <section className="py-12" id="artigos">
+          <h2 className="text-2xl font-semibold mb-6">Artigos em destaque</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {featuredPosts.map(post => (
+              <div key={post.slug} className="border p-4 rounded flex flex-col">
+                <h3 className="text-xl font-semibold mb-2">
+                  <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+                </h3>
+                <p className="text-sm text-gray-500 mb-2">{post.date}</p>
+                <p className="flex-1 mb-4">{post.excerpt}</p>
+                <Link href={`/blog/${post.slug}`} className="text-blue-600 font-medium mt-auto">Ler mais</Link>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="py-12 text-center">
+          <h2 className="text-2xl font-semibold mb-4">Traga seu desafio. Em 30 minutos mapeamos oportunidades reais.</h2>
+          <Link href="/contato" className="inline-block px-6 py-3 bg-blue-600 text-white rounded">Agendar conversa</Link>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/next-site/pages/projetos/[slug].js
+++ b/next-site/pages/projetos/[slug].js
@@ -1,0 +1,42 @@
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import { projects } from '../../data/projects'
+
+export default function Projeto() {
+  const router = useRouter()
+  const { slug } = router.query
+  const project = projects.find(p => p.slug === slug)
+  if (!project) return null
+  return (
+    <>
+      <Head>
+        <title>{project.title} | Projeto | Edu Prado</title>
+        <meta name="description" content={project.excerpt} />
+        <meta property="og:title" content={project.title} />
+        <meta property="og:description" content={project.excerpt} />
+      </Head>
+      <main className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-4">{project.title}</h1>
+        <p className="mb-6">{project.excerpt}</p>
+        <div className="space-y-6">
+          <section>
+            <h2 className="text-2xl font-semibold mb-2">Desafio</h2>
+            <p>{project.challenge}</p>
+          </section>
+          <section>
+            <h2 className="text-2xl font-semibold mb-2">Abordagem</h2>
+            <p>{project.approach}</p>
+          </section>
+          <section>
+            <h2 className="text-2xl font-semibold mb-2">Resultado</h2>
+            <p>{project.result}</p>
+          </section>
+          <section>
+            <h2 className="text-2xl font-semibold mb-2">Aprendizados</h2>
+            <p>{project.learnings}</p>
+          </section>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/next-site/pages/projetos/index.js
+++ b/next-site/pages/projetos/index.js
@@ -1,0 +1,24 @@
+import Head from 'next/head'
+import ProjectCard from '../../components/ProjectCard'
+import { projects } from '../../data/projects'
+
+export default function Projetos() {
+  return (
+    <>
+      <Head>
+        <title>Projetos | Edu Prado</title>
+        <meta name="description" content="Estudos de caso com resultados e aprendizados." />
+        <meta property="og:title" content="Projetos | Edu Prado" />
+        <meta property="og:description" content="Estudos de caso com resultados e aprendizados." />
+      </Head>
+      <main className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-6">Projetos</h1>
+        <div className="grid gap-6 md:grid-cols-3">
+          {projects.map(p => (
+            <ProjectCard key={p.slug} {...p} />
+          ))}
+        </div>
+      </main>
+    </>
+  )
+}

--- a/next-site/pages/sobre.js
+++ b/next-site/pages/sobre.js
@@ -1,0 +1,31 @@
+import Head from 'next/head'
+
+export default function Sobre() {
+  return (
+    <>
+      <Head>
+        <title>Sobre | Edu Prado</title>
+        <meta name="description" content="Ajudo líderes a decidir e executar IA onde faz diferença." />
+        <meta property="og:title" content="Sobre | Edu Prado" />
+        <meta property="og:description" content="Ajudo líderes a decidir e executar IA onde faz diferença." />
+      </Head>
+      <main className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-4">Sobre</h1>
+        <p className="mb-6">Ajudo líderes a decidir e executar IA onde faz diferença. Minha abordagem é prática, mensurável e livre de hype.</p>
+        <h2 className="text-2xl font-semibold mb-2">Hoje eu atuo em</h2>
+        <ul className="list-disc list-inside mb-6">
+          <li>Consultoria e projetos-piloto de IA</li>
+          <li>Palestras e workshops executivos</li>
+          <li>Mentorias 1:1 e advisory</li>
+          <li>Conteúdo aberto em blog e newsletter</li>
+        </ul>
+        <h2 className="text-2xl font-semibold mb-2">Como cheguei aqui</h2>
+        <p className="mb-6">Foram mais de duas décadas no mercado financeiro liderando times de tecnologia, dados e Open Finance. Vivi a transição de sistemas legados para plataformas abertas e vi de perto o que funciona e o que é apenas buzzword. Hoje aplico essa experiência para conectar IA a problemas reais de negócios e setor público.</p>
+        <div className="flex gap-4">
+          <a href="https://www.linkedin.com/in/eduprado" className="text-blue-600">LinkedIn</a>
+          <a href="/blog" className="text-blue-600">Blog</a>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/next-site/postcss.config.js
+++ b/next-site/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/next-site/styles/globals.css
+++ b/next-site/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply antialiased;
+}

--- a/next-site/tailwind.config.js
+++ b/next-site/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./pages/**/*.{js,jsx}', './components/**/*.{js,jsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js + Tailwind site with pages for home, blog, projects and contact
- add sample posts and projects content
- include QA checklist and deployment instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896774304708333a8a0f24fac7e04e2