### PR TITLE
Limit Google ads on homepage

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -23,6 +23,7 @@ body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     color: var(--text-color);
     line-height: 1.6;
+    padding-bottom: 70px;
 }
 
 .container {
@@ -1152,4 +1153,13 @@ body {
         margin: 1rem 0;
         padding: 0.5rem;
     }
-} 
+}
+
+.floating-ad {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+    text-align: center;
+}

--- a/index.html
+++ b/index.html
@@ -22,12 +22,6 @@
     <!-- Google AdSense -->
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7782077901383981"
      crossorigin="anonymous"></script>
-    <script>
-        (adsbygoogle = window.adsbygoogle || []).push({
-            google_ad_client: "ca-pub-7782077901383981",
-            overlays: { bottom: true }
-        });
-    </script>
     
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -284,6 +278,16 @@
             </div>
         </div>
     </footer>
+
+    <div class="floating-ad">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="ca-pub-7782077901383981"
+             data-ad-slot="8920423574"
+             data-ad-format="auto"
+             data-full-width-responsive="true"></ins>
+        <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+    </div>
 
     <!-- Scripts -->
     <script src="js/contact.js"></script>


### PR DESCRIPTION
## Summary
- remove extra AdSense initialization on index
- add explicit floating ad block and keep footer ad
- style floating ad and adjust page padding

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68acb24cea1883339e398e03a35b4621