### PR TITLE
Limit homepage to footer and floating ads

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -23,6 +23,7 @@ body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     color: var(--text-color);
     line-height: 1.6;
+    padding-bottom: 70px;
 }
 
 .container {
@@ -1152,4 +1153,51 @@ body {
         margin: 1rem 0;
         padding: 0.5rem;
     }
-} 
+}
+
+
+.floating-ad {
+    position: fixed;
+    bottom: 0;
+    top: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 320px;
+    z-index: 1000;
+    text-align: center;
+    background: #fff;
+    padding: 4px;
+    border-radius: 8px 8px 0 0;
+    box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+    box-sizing: border-box;
+}
+
+.floating-ad-open {
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 999;
+    padding: 4px 8px;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 8px 8px 0 0;
+    cursor: pointer;
+    display: none;
+}
+
+.floating-ad-close {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 18px;
+    padding: 0;
+}

--- a/index.html
+++ b/index.html
@@ -22,12 +22,6 @@
     <!-- Google AdSense -->
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7782077901383981"
      crossorigin="anonymous"></script>
-    <script>
-        (adsbygoogle = window.adsbygoogle || []).push({
-            google_ad_client: "ca-pub-7782077901383981",
-            overlays: { bottom: true }
-        });
-    </script>
     
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -285,9 +279,20 @@
         </div>
     </footer>
 
+    <div class="floating-ad">
+        <button class="floating-ad-close" aria-label="Fechar anúncio">&times;</button>
+        <ins class="adsbygoogle"
+             style="display:inline-block;width:320px;height:50px"
+             data-ad-client="ca-pub-7782077901383981"
+             data-ad-slot="8920423574"></ins>
+        <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+    </div>
+    <button class="floating-ad-open" aria-label="Mostrar anúncio" hidden>Anúncio</button>
+
     <!-- Scripts -->
     <script src="js/contact.js"></script>
     <script src="js/newsletter.js"></script>
     <script src="js/profile.js"></script>
+    <script src="js/floating-ad.js"></script>
 </body>
-</html> 
+</html>

--- a/js/floating-ad.js
+++ b/js/floating-ad.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const closeBtn = document.querySelector('.floating-ad-close');
+  const floatingAd = document.querySelector('.floating-ad');
+  const openBtn = document.querySelector('.floating-ad-open');
+
+  if (closeBtn && floatingAd && openBtn) {
+    closeBtn.addEventListener('click', () => {
+      floatingAd.style.display = 'none';
+      openBtn.style.display = 'block';
+    });
+
+    openBtn.addEventListener('click', () => {
+      floatingAd.style.display = 'block';
+      openBtn.style.display = 'none';
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- keep only footer AdSense unit on homepage
- add minimizable floating ad with reopen button
- center floating banner responsively at bottom

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68acb24cea1883339e398e03a35b4621