### PR TITLE
Harden auth and API, sanitize admin UI, and switch Pages workflow to publish static _site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,7 @@
 name: Deploy Next.js site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main", "master"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # Manual only: the simplified production site is deployed by pages.yml.
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy static site to GitHub Pages
 
 on:
   push:
@@ -23,16 +23,26 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
-      - name: Configure CNAME
+      - name: Prepare static site artifact
         run: |
-          echo "eduprado.me" > CNAME
-          
+          mkdir -p _site
+          cp index.html _site/
+          cp post.html _site/ 2>/dev/null || true
+          cp ads.txt _site/ 2>/dev/null || true
+          cp site.webmanifest _site/ 2>/dev/null || true
+          cp admin.html _site/ 2>/dev/null || true
+          cp admin-login.html _site/ 2>/dev/null || true
+          cp -R css js images admin analisadados _site/
+          cp -R data _site/ 2>/dev/null || true
+          touch _site/.nojekyll
+          echo "eduprado.me" > _site/CNAME
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
+          path: '_site'
 
   deploy:
     needs: build
@@ -43,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,138 @@
+# Deploy do EduPrado.me (GitHub Pages + Render)
+
+Este projeto tem duas partes em produção:
+
+1. **Site estático** (`eduprado.me`) publicado pelo **GitHub Pages**.
+2. **Backend/API** (`eduprado-backend.onrender.com`) publicado pelo **Render**.
+
+> Regra prática: alterações visuais do site vão para o **GitHub Pages**; alterações de API, login/admin e posts vão para o **Render**.
+
+## 1) Deploy do site no GitHub Pages
+
+O site simplificado atual é estático e usa o `index.html` da raiz do repositório.
+
+### Como publicar
+
+1. Entre no GitHub.
+2. Abra o repositório `Edu-Prado.github.io`.
+3. Faça merge/push das alterações na branch `main`.
+4. Vá em **Actions**.
+5. Abra o workflow **Deploy static site to GitHub Pages**.
+6. Aguarde ficar verde.
+7. Acesse `https://eduprado.me`.
+
+### Configuração esperada em Settings > Pages
+
+Em **Settings > Pages**:
+
+- **Source**: `GitHub Actions`
+- Domínio customizado: `eduprado.me`
+
+O workflow `.github/workflows/pages.yml` prepara uma pasta `_site` somente com os arquivos públicos necessários e publica essa pasta no GitHub Pages.
+
+### O que NÃO usar como deploy principal agora
+
+O workflow `.github/workflows/deploy.yml` de Next.js ficou **manual apenas** para evitar conflito. Ele não deve rodar automaticamente enquanto a versão simplificada estática for a produção.
+
+## 2) Deploy do backend no Render
+
+O backend que atende o admin deve ser o serviço Node/Express do Render apontando para a pasta `api`.
+
+### Configuração esperada do serviço Render
+
+No Render, abra o serviço `eduprado-backend` e confira em **Settings**:
+
+- **Root Directory**: `api`
+- **Build Command**: `npm install`
+- **Start Command**: `npm start`
+- **Branch**: `main`
+- **Auto-Deploy**: `On Commit` (recomendado) ou manual se preferir controlar tudo.
+
+Com essa configuração, o Render usa `api/package.json`, cujo start roda `node server.js` dentro da pasta `api`. O arquivo `render.yaml` na raiz do repositório também registra essa configuração como Blueprint para evitar apontar o serviço para `backend/` ou para a raiz por engano.
+
+### Variáveis de ambiente obrigatórias
+
+Em **Environment**, configure:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+Para criar o primeiro admin, ligue temporariamente:
+
+- `ENABLE_PUBLIC_REGISTER=true`
+
+Depois de criar o usuário, desligue/remova:
+
+- `ENABLE_PUBLIC_REGISTER`
+
+ou defina:
+
+- `ENABLE_PUBLIC_REGISTER=false`
+
+### Como publicar no Render
+
+#### Opção A — automático
+
+Se **Auto-Deploy** estiver ligado, basta fazer merge/push na branch `main`. O Render detecta o commit e faz o deploy.
+
+#### Opção B — manual
+
+1. Abra o Render.
+2. Entre no serviço `eduprado-backend`.
+3. Clique em **Manual Deploy**.
+4. Clique em **Deploy latest commit**.
+5. Aguarde o deploy finalizar sem erro.
+
+## 3) Testes rápidos após o deploy
+
+### Backend
+
+Abra no navegador:
+
+- `https://eduprado-backend.onrender.com/`
+
+Resultado esperado: JSON com `EduPrado API está online`.
+
+Abra também:
+
+- `https://eduprado-backend.onrender.com/api/auth/verify`
+
+Resultado esperado sem login: erro de token ausente/inválido. Isso é bom: significa que a rota existe.
+
+Se aparecer `Cannot GET /api/auth/verify`, o Render ainda está rodando código antigo ou está apontando para a pasta errada.
+
+### Site
+
+Abra:
+
+- `https://eduprado.me`
+
+Resultado esperado: site estático atualizado.
+
+## 4) Como criar o primeiro admin depois do deploy correto
+
+No PowerShell do Windows:
+
+```powershell
+$body = @{
+  name = "Eduardo"
+  email = "seu-email@dominio.com"
+  password = "TroquePorUmaSenhaForte!123"
+} | ConvertTo-Json
+
+Invoke-RestMethod -Method POST `
+  -Uri "https://eduprado-backend.onrender.com/api/auth/register" `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+Depois de criar o usuário, volte ao Render e desligue `ENABLE_PUBLIC_REGISTER`.
+
+## 5) Fontes oficiais usadas para este guia
+
+- Render: deploy automático/manual, build/start commands e Manual Deploy.
+  <https://render.com/docs/deploys>
+- Render: monorepo/root directory.
+  <https://render.com/docs/monorepo-support>
+- GitHub Pages: publicar via branch ou GitHub Actions e configurar Source.
+  <https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site>

--- a/GUIA_RENDER_ADMIN.md
+++ b/GUIA_RENDER_ADMIN.md
@@ -1,0 +1,145 @@
+# Guia rápido (Render): onde ficam as configurações do backend do admin
+
+Este guia é para quando você já está no Render, abriu o serviço `eduprado-backend`, mas não encontra onde configurar login/usuário.
+
+## 1) Confirmar se é o serviço certo
+No serviço aberto, vá em **Logs** e procure por mensagens que indiquem Node/Express e rotas `/api/auth`.
+
+Dica: no navegador, teste:
+
+- `https://SEU_BACKEND/api/health` (se existir)
+- `https://SEU_BACKEND/api/auth/verify` (deve responder algo como erro de token ausente)
+
+Se não houver nada de `/api/auth`, provavelmente você está no serviço errado (frontend estático) e não no backend.
+
+## 2) Onde ficam as variáveis no Render
+Dentro do serviço correto (`eduprado-backend`):
+
+1. Clique em **Environment** (ou **Environment Variables**).
+2. Clique em **Add Environment Variable**.
+3. Adicione:
+   - `JWT_SECRET` = um segredo forte (texto longo e aleatório).
+   - `ENABLE_PUBLIC_REGISTER` = `true` (temporário, só para criar o primeiro usuário).
+4. Salve e aguarde o deploy automático.
+
+## 3) Criar o primeiro usuário (um comando)
+No seu terminal local:
+
+```bash
+curl -X POST https://SEU_BACKEND/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Seu Nome","email":"seu@email.com","password":"SenhaForte!123"}'
+```
+
+Se retornar sucesso, usuário criado.
+
+
+## 3.1) "Onde é meu terminal local?" (passo a passo para leigos)
+**Terminal local** = o programa de comandos do seu próprio computador (não é no Render).
+
+- **Windows**: abra o menu Iniciar e procure por **PowerShell** (ou **Prompt de Comando**).
+- **Mac**: abra o app **Terminal** (Aplicativos > Utilitários > Terminal).
+- **Linux**: abra o app **Terminal** da sua distribuição.
+
+Depois, copie e cole o comando `curl` nesse terminal e aperte **Enter**.
+
+Se aparecer mensagem tipo `curl: command not found`, use uma destas alternativas:
+1. Instalar o `curl` no seu sistema operacional; ou
+2. Usar o **Postman/Insomnia** para fazer o mesmo `POST`; ou
+3. Usar o **Render Shell** do serviço backend e executar o mesmo comando lá (quando disponível).
+
+
+## 3.2) PowerShell (Windows): comando correto
+No **PowerShell**, `curl` normalmente é um apelido de `Invoke-WebRequest` (por isso `-X`, `-H` e `-d` dão erro).
+
+Use um destes formatos:
+
+### Opção A — PowerShell nativo (recomendado)
+```powershell
+$body = @{
+  name = "Eduardo"
+  email = "seu-email@dominio.com"
+  password = "TroquePorUmaSenhaForte!123"
+} | ConvertTo-Json
+
+Invoke-RestMethod -Method POST `
+  -Uri "https://SEU_BACKEND/api/auth/register" `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+### Opção B — usar curl real no Windows
+```powershell
+curl.exe -X POST "https://SEU_BACKEND/api/auth/register" -H "Content-Type: application/json" -d "{\"name\":\"Eduardo\",\"email\":\"seu-email@dominio.com\",\"password\":\"TroquePorUmaSenhaForte!123\"}"
+```
+
+> Importante: no PowerShell, quebra de linha usa crase (`` ` ``), não barra invertida (`\`) como no bash.
+
+## 3.3) Se aparecer erro **404 Não Localizado**
+Esse erro indica que a URL existe, mas a rota `/api/auth/register` não foi encontrada no serviço que você chamou.
+
+Checklist rápido:
+
+1. **Confirme a URL do backend**: precisa ser a do serviço Node/Express (não a do site estático).
+2. Abra no navegador:
+   - `https://SEU_BACKEND/` (deve responder algo do app)
+   - `https://SEU_BACKEND/api/auth/verify` (deve retornar erro de auth, não 404)
+3. Se `/api/auth/verify` também der 404:
+   - você está no serviço errado **ou**
+   - o deploy desse backend está desatualizado/falhou.
+4. No Render, abra **Logs** do serviço backend e confirme se ele subiu sem erro.
+5. Verifique se as rotas estão publicadas: no código atual, o backend Supabase em `api/server.js` também expõe `/api/auth/login`, `/api/auth/verify` e `/api/auth/register`.
+
+### Resultado esperado por status
+- **404**: endpoint não existe nesse serviço (URL errada ou deploy incorreto).
+- **403**: endpoint existe, mas registro público está bloqueado (normal em produção sem `ENABLE_PUBLIC_REGISTER=true`).
+- **500**: endpoint existe, mas falta configuração como `JWT_SECRET`.
+
+
+## 3.4) Se aparecer **Cannot GET /** ou **Cannot GET /api/auth/verify**
+Isso confirma que existe um serviço Express respondendo nessa URL, mas ele está sem a rota esperada.
+
+Neste projeto havia dois servidores possíveis:
+
+- `server.js`: backend antigo com rotas Mongo/JWT em `/api/auth`.
+- `api/server.js`: backend publicado no Render para posts/Supabase.
+
+O domínio `https://eduprado-backend.onrender.com` está se comportando como o `api/server.js`. Por isso, o backend publicado precisava receber também as rotas de login do admin.
+
+Depois do deploy da correção, o comportamento esperado passa a ser:
+
+- `https://eduprado-backend.onrender.com/` deve retornar um JSON dizendo que a API está online.
+- `https://eduprado-backend.onrender.com/api/auth/verify` deve retornar erro de token ausente/inválido quando aberto sem login (isso é esperado e significa que a rota existe).
+- `POST /api/auth/register` deve retornar `403` se `ENABLE_PUBLIC_REGISTER` estiver desligado, ou criar o usuário se estiver temporariamente ligado.
+
+Se ainda aparecer `Cannot GET`, faça um **Manual Deploy** no Render e confira os **Logs** para garantir que a versão nova subiu.
+
+## 4) Fechar a porta de cadastro (importante)
+Volte ao Render e ajuste:
+
+- `ENABLE_PUBLIC_REGISTER=false` (ou remova a variável)
+
+Depois use o admin com:
+
+- usuário = seu email
+- senha = a senha criada
+
+## 5) Se você não achar “Environment”
+Isso normalmente acontece por um destes motivos:
+
+- Você abriu um **Static Site** em vez de um **Web Service**.
+- Você está em outro workspace/team.
+- Seu usuário tem permissão limitada no serviço.
+
+## 6) Checklist de diagnóstico rápido
+- O domínio do backend costuma ser algo como `*.onrender.com` e não o domínio do site estático.
+- O serviço backend precisa ter logs de inicialização Node (`server.js`, `Express`, etc.).
+- O frontend admin chama `/api/auth/login`; sem backend correto, login nunca funciona.
+
+
+## 7) Deploy: onde publicar cada parte
+
+- **GitHub Pages** publica o site estático (`eduprado.me`).
+- **Render** publica o backend/API (`eduprado-backend.onrender.com`).
+
+Para o passo a passo completo de deploy, veja `DEPLOYMENT.md`.

--- a/SECURITY_REVIEW_2026-04-24.md
+++ b/SECURITY_REVIEW_2026-04-24.md
@@ -1,0 +1,132 @@
+# Revisão de Segurança e Qualidade de Código (24/04/2026)
+
+## Escopo avaliado
+- Backend Express principal (`server.js` + `routes/*` + `middleware/*`)
+- Backend alternativo com Supabase (`api/server.js`)
+- Painel admin legado (`admin/js/admin.js`)
+- Cliente web principal (`js/*`)
+
+---
+
+## Resumo executivo
+Foram encontrados **riscos críticos** no painel administrativo legado e na API alternativa com Supabase. Os principais vetores são:
+1. **Autenticação client-side com credenciais hardcoded**.
+2. **Endpoints de escrita sem autenticação** (criação, edição e exclusão de posts).
+3. **Possível XSS** por uso de `innerHTML` sem sanitização.
+4. **Configurações inseguras de segredo JWT e CORS** no backend principal.
+
+Além disso, havia um bug funcional importante na rota de autenticação (`routes/auth.js`) que impedia o carregamento correto das rotas por import incorreto de middleware.
+
+---
+
+## Achados detalhados
+
+## 1) Credenciais hardcoded e autenticação burlável no admin legado (CRÍTICO)
+**Arquivo:** `admin/js/admin.js`
+
+- Usuário/senha administrativos estão em JavaScript público.
+- O estado de login depende apenas de `localStorage` (`adminLoggedIn=true`), sem validação robusta de sessão/token.
+
+**Impacto:** qualquer pessoa com acesso ao navegador pode descobrir/forjar autenticação e acessar o dashboard legado.
+
+**Recomendação:**
+- Remover autenticação client-side imediatamente.
+- Autenticar no servidor com senha hash + sessão/token assinado + expiração.
+- Migrar para o fluxo já existente com Supabase/Auth e descontinuar o painel legado.
+
+## 2) API Supabase com operações de escrita sem autenticação (CRÍTICO)
+**Arquivo:** `api/server.js`
+
+- Rotas `POST /api/posts`, `PUT /api/posts/:id`, `DELETE /api/posts/:id` e `DELETE /api/posts` não validam autenticação/autorização.
+- API inicializada com `SUPABASE_SERVICE_ROLE_KEY` (chave privilegiada).
+
+**Impacto:** caso endpoint esteja exposto, terceiros podem editar/apagar conteúdo integralmente.
+
+**Recomendação:**
+- Exigir autenticação forte em todas as operações de escrita.
+- Nunca expor `service role` ao cliente; manter apenas no servidor.
+- Implementar RBAC (ex.: apenas role `admin` escreve/deleta).
+
+## 3) Risco de XSS por renderização com `innerHTML` (ALTO)
+**Arquivo:** `admin/js/admin.js`
+
+- Conteúdo de post/tags é interpolado em HTML sem sanitização.
+
+**Impacto:** conteúdo malicioso pode executar JS no navegador de admins/visitantes.
+
+**Recomendação:**
+- Substituir por criação de nós via `document.createElement` + `textContent`.
+- Se `innerHTML` for inevitável, aplicar sanitização robusta (ex.: DOMPurify).
+
+## 4) Segredo JWT com fallback previsível (ALTO)
+**Arquivos:** `routes/auth.js`, `middleware/auth.js`
+
+- Há fallback para string estática caso `JWT_SECRET` não exista.
+
+**Impacto:** tokens podem ser forjados se ambiente estiver mal configurado.
+
+**Recomendação:**
+- Exigir `JWT_SECRET` obrigatório na inicialização.
+- Falhar boot do servidor se variável não estiver definida.
+
+## 5) Endpoint de registro aberto em rota marcada como "desenvolvimento" (MÉDIO/ALTO)
+**Arquivo:** `routes/auth.js`
+
+- `POST /register` está ativo sem trava de ambiente.
+
+**Impacto:** criação indevida de usuários em produção.
+
+**Recomendação:**
+- Bloquear em produção (feature flag/env guard) ou restringir por papel admin.
+
+## 6) CORS permissivo no backend principal (MÉDIO)
+**Arquivo:** `server.js`
+
+- `app.use(cors())` permite qualquer origem por padrão.
+
+**Impacto:** amplia superfície de abuso por navegadores de terceiros.
+
+**Recomendação:**
+- Definir allowlist explícita por ambiente.
+
+## 7) Bug funcional corrigido nesta revisão (ALTO - disponibilidade)
+**Arquivo alterado:** `routes/auth.js`
+
+- Corrigido import do middleware `auth` (`const { auth } = require('../middleware/auth')`).
+
+**Impacto anterior:** erro em tempo de carregamento das rotas (`Route.get() requires a callback function but got a [object Object]`).
+
+---
+
+## Priorização sugerida (ordem de execução)
+1. **Imediato (0-24h):**
+   - Retirar painel admin legado do ar ou proteger por autenticação real.
+   - Proteger rotas de escrita em `api/server.js`.
+2. **Curto prazo (1-3 dias):**
+   - Eliminar fallback de `JWT_SECRET`.
+   - Fechar `/register` em produção.
+   - Restringir CORS.
+3. **Médio prazo (até 1 semana):**
+   - Sanitização anti-XSS e revisão de renderizações dinâmicas.
+   - Rate limiting e logging de segurança para login e endpoints críticos.
+
+---
+
+## Evidência de validação executada
+Foi reproduzido localmente o erro de middleware com o comando:
+
+```bash
+node -e "require('./routes/auth'); console.log('ok')"
+```
+
+Antes da correção, o carregamento das rotas falhava por middleware inválido. Após a correção, o módulo carrega corretamente.
+
+---
+
+## Atualizações aplicadas após revisão (24/04/2026)
+- Removida autenticação com credenciais hardcoded no `admin/js/admin.js`; login agora usa backend (`/api/auth/login`) e valida sessão via `/api/auth/verify`.
+- Endpoints de escrita em `api/server.js` agora exigem token e role `admin`.
+- Adicionada validação básica de payload para criação/edição de posts em `api/server.js`.
+- `server.js` atualizado para usar allowlist de CORS via variável `CORS_ORIGINS`.
+- `routes/auth.js` e `middleware/auth.js` deixam de usar segredo JWT hardcoded em fallback; agora registram erro de configuração e retornam falha segura quando ausente.
+- `routes/auth.js` restringe `POST /register` em produção, exceto quando `ENABLE_PUBLIC_REGISTER=true`.

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -1,39 +1,61 @@
-// Credenciais (em produção, isso deve estar no servidor)
-const ADMIN_CREDENTIALS = {
-    username: 'admin',
-    password: 'admin03012010'
-};
-
 const API_URL = window.location.hostname === 'localhost' 
     ? 'http://localhost:3000'
     : 'https://eduprado-backend.onrender.com';
 
+const AUTH_TOKEN_KEY = 'adminAuthToken';
+
 // Gerenciamento de autenticação
 async function login(username, password) {
     try {
-        // Aqui você faria a chamada para o backend
-        // Por enquanto, vamos simular com uma senha hardcoded
-        if (username === ADMIN_CREDENTIALS.username && password === ADMIN_CREDENTIALS.password) {
-            localStorage.setItem('adminLoggedIn', 'true');
-            window.location.href = 'dashboard.html';
-        } else {
-            alert('Usuário ou senha incorretos');
+        const response = await fetch(`${API_URL}/api/auth/login`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                email: username,
+                password
+            })
+        });
+
+        const data = await response.json();
+        if (!response.ok || !data.token) {
+            throw new Error(data.message || 'Usuário ou senha incorretos');
         }
+
+        localStorage.setItem(AUTH_TOKEN_KEY, data.token);
+        window.location.href = 'dashboard.html';
     } catch (error) {
         console.error('Erro ao fazer login:', error);
-        alert('Erro ao fazer login');
+        alert(error.message || 'Erro ao fazer login');
     }
 }
 
-function checkAuth() {
-    const isLoggedIn = localStorage.getItem('adminLoggedIn') === 'true';
-    if (!isLoggedIn) {
+async function checkAuth() {
+    const token = localStorage.getItem(AUTH_TOKEN_KEY);
+    if (!token) {
         window.location.href = 'index.html';
+        return false;
+    }
+
+    try {
+        const response = await fetch(`${API_URL}/api/auth/verify`, {
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error('Sessão inválida');
+        }
+        return true;
+    } catch (error) {
+        localStorage.removeItem(AUTH_TOKEN_KEY);
+        window.location.href = 'index.html';
+        return false;
     }
 }
 
 function logout() {
-    localStorage.removeItem('adminLoggedIn');
+    localStorage.removeItem(AUTH_TOKEN_KEY);
     window.location.href = 'index.html';
 }
 
@@ -71,13 +93,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Se estiver na página do dashboard
     if (document.querySelector('.admin-dashboard')) {
-        checkAuth();
-        loadPosts();
+        checkAuth().then(isAuthenticated => {
+            if (isAuthenticated) {
+                loadPosts();
+            }
+        });
     }
 });
 
 // Funções para gerenciar posts
 let currentPosts = [];
+
+function escapeHtml(value = '') {
+    return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;');
+}
 
 async function loadPosts() {
     try {
@@ -97,10 +131,10 @@ function displayPosts(posts) {
     const postsHTML = posts.map(post => `
         <div class="post-item">
             <div class="post-info">
-                <h3>${post.title}</h3>
+                <h3>${escapeHtml(post.title)}</h3>
                 <p class="post-meta">
-                    <span class="date">${post.date}</span>
-                    <span class="tags">${post.tags.join(', ')}</span>
+                    <span class="date">${escapeHtml(post.date)}</span>
+                    <span class="tags">${escapeHtml((post.tags || []).join(', '))}</span>
                 </p>
             </div>
             <div class="post-actions">

--- a/api/server.js
+++ b/api/server.js
@@ -21,10 +21,178 @@ const supabase = createClient(
     process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
+const getUserRole = (user) => user?.app_metadata?.role || user?.user_metadata?.role;
+
+const getBearerToken = (req) => {
+    const authHeader = req.headers.authorization || '';
+    return authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+};
+
+const getAuthenticatedAdmin = async (req, res) => {
+    const token = getBearerToken(req);
+
+    if (!token) {
+        res.status(401).json({ error: 'Token não fornecido' });
+        return null;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+        res.status(401).json({ error: 'Token inválido' });
+        return null;
+    }
+
+    const role = getUserRole(data.user);
+    if (role !== 'admin') {
+        res.status(403).json({ error: 'Acesso negado' });
+        return null;
+    }
+
+    return data.user;
+};
+
+const requireAdminAuth = async (req, res, next) => {
+    try {
+        const user = await getAuthenticatedAdmin(req, res);
+        if (!user) return;
+
+        req.user = user;
+        next();
+    } catch (err) {
+        console.error('Erro ao validar autenticação:', err);
+        res.status(500).json({ error: 'Erro ao validar autenticação' });
+    }
+};
+
+const validatePostPayload = (req, res, next) => {
+    const { title, category, content, imageUrl } = req.body;
+    if (!title || !category || !content) {
+        return res.status(400).json({ error: 'Campos obrigatórios ausentes' });
+    }
+
+    if ([title, category].some(field => typeof field !== 'string' || field.length > 200)) {
+        return res.status(400).json({ error: 'Título/categoria inválidos' });
+    }
+
+    if (typeof content !== 'string' || content.length > 50000) {
+        return res.status(400).json({ error: 'Conteúdo inválido' });
+    }
+
+    if (imageUrl && (typeof imageUrl !== 'string' || imageUrl.length > 2000)) {
+        return res.status(400).json({ error: 'URL da imagem inválida' });
+    }
+
+    next();
+};
+
 // Middleware para logging
 app.use((req, res, next) => {
     console.log(`${new Date().toISOString()} - ${req.method} ${req.url}`);
     next();
+});
+
+// Rota raiz/healthcheck para facilitar diagnóstico no navegador e no Render
+app.get('/', (req, res) => {
+    res.json({
+        message: 'EduPrado API está online',
+        endpoints: {
+            health: '/api/test',
+            login: '/api/auth/login',
+            verify: '/api/auth/verify',
+            posts: '/api/posts'
+        }
+    });
+});
+
+// Rotas de autenticação do admin usando Supabase Auth
+app.post('/api/auth/login', async (req, res) => {
+    try {
+        const { email, password } = req.body;
+
+        if (!email || !password) {
+            return res.status(400).json({ message: 'Por favor, preencha email e senha' });
+        }
+
+        const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+        if (error || !data?.session?.access_token || !data?.user) {
+            return res.status(401).json({ message: 'Credenciais inválidas' });
+        }
+
+        if (getUserRole(data.user) !== 'admin') {
+            return res.status(403).json({ message: 'Usuário sem permissão de administrador' });
+        }
+
+        res.json({
+            token: data.session.access_token,
+            user: {
+                id: data.user.id,
+                name: data.user.user_metadata?.name || data.user.email,
+                email: data.user.email
+            }
+        });
+    } catch (err) {
+        console.error('Erro no login:', err);
+        res.status(500).json({ message: 'Erro interno do servidor' });
+    }
+});
+
+app.get('/api/auth/verify', async (req, res) => {
+    try {
+        const user = await getAuthenticatedAdmin(req, res);
+        if (!user) return;
+
+        res.json({
+            user: {
+                id: user.id,
+                name: user.user_metadata?.name || user.email,
+                email: user.email
+            }
+        });
+    } catch (err) {
+        console.error('Erro ao verificar autenticação:', err);
+        res.status(500).json({ message: 'Erro ao verificar autenticação' });
+    }
+});
+
+app.post('/api/auth/register', async (req, res) => {
+    try {
+        if (process.env.NODE_ENV === 'production' && process.env.ENABLE_PUBLIC_REGISTER !== 'true') {
+            return res.status(403).json({ message: 'Registro público desabilitado em produção' });
+        }
+
+        const { name, email, password } = req.body;
+        if (!name || !email || !password) {
+            return res.status(400).json({ message: 'Por favor, preencha nome, email e senha' });
+        }
+
+        if (password.length < 8) {
+            return res.status(400).json({ message: 'A senha deve ter pelo menos 8 caracteres' });
+        }
+
+        const { data, error } = await supabase.auth.admin.createUser({
+            email,
+            password,
+            email_confirm: true,
+            app_metadata: { role: 'admin' },
+            user_metadata: { name, role: 'admin' }
+        });
+
+        if (error || !data?.user) {
+            return res.status(400).json({ message: error?.message || 'Erro ao criar usuário' });
+        }
+
+        res.status(201).json({
+            message: 'Usuário admin criado com sucesso',
+            user: {
+                id: data.user.id,
+                name: data.user.user_metadata?.name || data.user.email,
+                email: data.user.email
+            }
+        });
+    } catch (err) {
+        console.error('Erro ao registrar usuário:', err);
+        res.status(500).json({ message: 'Erro interno do servidor' });
+    }
 });
 
 // Rota de teste
@@ -84,7 +252,7 @@ app.get('/api/posts/:id', async (req, res) => {
 });
 
 // Criar novo post
-app.post('/api/posts', async (req, res) => {
+app.post('/api/posts', requireAdminAuth, validatePostPayload, async (req, res) => {
     const { title, category, content, imageUrl } = req.body;
     console.log('Criando novo post:', { title, category, imageUrl });
 
@@ -117,7 +285,7 @@ app.post('/api/posts', async (req, res) => {
 });
 
 // Atualizar post
-app.put('/api/posts/:id', async (req, res) => {
+app.put('/api/posts/:id', requireAdminAuth, validatePostPayload, async (req, res) => {
     const { title, category, content, imageUrl } = req.body;
     console.log(`Atualizando post ${req.params.id}:`, { title, category, imageUrl });
 
@@ -154,7 +322,7 @@ app.put('/api/posts/:id', async (req, res) => {
 });
 
 // Deletar post
-app.delete('/api/posts/:id', async (req, res) => {
+app.delete('/api/posts/:id', requireAdminAuth, async (req, res) => {
     console.log(`Deletando post ${req.params.id}`);
 
     try {
@@ -177,7 +345,7 @@ app.delete('/api/posts/:id', async (req, res) => {
 });
 
 // Deletar todos os posts
-app.delete('/api/posts', async (req, res) => {
+app.delete('/api/posts', requireAdminAuth, async (req, res) => {
     console.log('Deletando todos os posts');
 
     try {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,10 +1,18 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 
-const JWT_SECRET = process.env.JWT_SECRET || 'sua-chave-secreta-aqui';
+const JWT_SECRET = process.env.JWT_SECRET;
+
+if (!JWT_SECRET) {
+    console.error('[SECURITY] JWT_SECRET não definido. Configure a variável de ambiente.');
+}
 
 const auth = async (req, res, next) => {
     try {
+        if (!JWT_SECRET) {
+            return res.status(500).json({ message: 'Configuração de autenticação inválida' });
+        }
+
         // Pegar token do header
         const token = req.header('Authorization')?.replace('Bearer ', '');
         

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: eduprado-backend
+    runtime: node
+    rootDir: api
+    buildCommand: npm install
+    startCommand: npm start
+    autoDeploy: true
+    envVars:
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
+      - key: ENABLE_PUBLIC_REGISTER
+        value: "false"

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,15 +3,23 @@ const router = express.Router();
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
-const auth = require('../middleware/auth');
+const { auth } = require('../middleware/auth');
 
 // Configurações do JWT
-const JWT_SECRET = process.env.JWT_SECRET || 'sua-chave-secreta-aqui';
+const JWT_SECRET = process.env.JWT_SECRET;
 const JWT_EXPIRES_IN = '24h';
+
+if (!JWT_SECRET) {
+    console.error('[SECURITY] JWT_SECRET não definido. Configure a variável de ambiente.');
+}
 
 // Rota de login
 router.post('/login', async (req, res) => {
     try {
+        if (!JWT_SECRET) {
+            return res.status(500).json({ message: 'Configuração de autenticação inválida' });
+        }
+
         const { email, password } = req.body;
 
         // Validar campos
@@ -61,6 +69,14 @@ router.get('/verify', auth, (req, res) => {
 // Rota para criar usuário (apenas para desenvolvimento)
 router.post('/register', async (req, res) => {
     try {
+        if (!JWT_SECRET) {
+            return res.status(500).json({ message: 'Configuração de autenticação inválida' });
+        }
+
+        if (process.env.NODE_ENV === 'production' && process.env.ENABLE_PUBLIC_REGISTER !== 'true') {
+            return res.status(403).json({ message: 'Registro público desabilitado em produção' });
+        }
+
         const { name, email, password } = req.body;
 
         // Validar campos

--- a/server.js
+++ b/server.js
@@ -12,8 +12,21 @@ const statsRoutes = require('./routes/stats');
 
 const app = express();
 
+const allowedOrigins = (process.env.CORS_ORIGINS || 'http://localhost:3000,http://127.0.0.1:3000,https://eduprado.me')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
 // Middlewares
-app.use(cors());
+app.use(cors({
+    origin: (origin, callback) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+            return callback(null, true);
+        }
+        return callback(new Error('Origem não permitida pelo CORS'));
+    },
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
+}));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
### Motivation

- Remove insecure client-side credentials and protect write operations by enforcing server-side authentication and role checks.  
- Improve security posture by removing JWT fallback secrets, restricting public registration in production, and tightening CORS.  
- Publish a simplified static site via GitHub Pages from a curated `_site` artifact and document deployment steps for GitHub Pages and Render.  

### Description

- Replace client-side hardcoded admin credentials in `admin/js/admin.js` with real backend login against `POST /api/auth/login`, store tokens in `localStorage` under `adminAuthToken`, add `checkAuth()` to call `GET /api/auth/verify`, add `escapeHtml()` to mitigate XSS, and adjust UI flows (`login`, `logout`, `loadPosts`).  
- Rework the Supabase-backed API in `api/server.js` by adding health endpoint, admin auth helpers (`getAuthenticatedAdmin`, `requireAdminAuth`), role checks, `POST /api/auth/login`, `GET /api/auth/verify`, guarded `POST /api/auth/register` (disabled in production unless `ENABLE_PUBLIC_REGISTER=true`), payload validation middleware `validatePostPayload`, and protect all write endpoints (`POST`, `PUT`, `DELETE`) with admin auth.  
- Tighten JWT handling in `middleware/auth.js` by removing insecure fallback, logging missing `JWT_SECRET`, and returning a fail-safe error when the secret is not configured.  
- Harden `routes/auth.js` to check for `JWT_SECRET`, restrict public registration in production, fix middleware import usage, and ensure errors return appropriate status codes.  
- Restrict CORS in `server.js` with an allowlist read from `CORS_ORIGINS` (defaults provided) instead of permissive `cors()` usage.  
- Update GitHub Actions: make `/.github/workflows/deploy.yml` manual-only to avoid conflicting automatic Next.js deploys, and change `/.github/workflows/pages.yml` to prepare a `_site` folder, use `actions/configure-pages@v5`, upload `_site` with `actions/upload-pages-artifact@v3`, and deploy with `actions/deploy-pages@v4`.  
- Add operational artifacts and docs: `DEPLOYMENT.md`, `GUIA_RENDER_ADMIN.md`, `SECURITY_REVIEW_2026-04-24.md`, and a `render.yaml` for the Render service configuration.  

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb72b448a0833396ab90984fdae623)